### PR TITLE
feat: 내 정보 관련 API 생성

### DIFF
--- a/src/main/java/com/example/mini_community/common/config/SecurityConfig.java
+++ b/src/main/java/com/example/mini_community/common/config/SecurityConfig.java
@@ -43,6 +43,7 @@ public class SecurityConfig {
                                 new AntPathRequestMatcher("/boards/*/like"),
                                 new AntPathRequestMatcher("/boards/*/comments"),
                                 new AntPathRequestMatcher("/boards/*/comments/*"),
+                                new AntPathRequestMatcher("/members"),
                                 new AntPathRequestMatcher("/members/*")
                         ).permitAll()
                         .anyRequest().authenticated()

--- a/src/main/java/com/example/mini_community/common/config/SecurityConfig.java
+++ b/src/main/java/com/example/mini_community/common/config/SecurityConfig.java
@@ -37,6 +37,7 @@ public class SecurityConfig {
                                 new AntPathRequestMatcher("/auth/join"),
                                 new AntPathRequestMatcher("/auth/login"),
                                 new AntPathRequestMatcher("/auth/token"),
+                                new AntPathRequestMatcher("/auth/leave"),
                                 new AntPathRequestMatcher("/user"),
                                 new AntPathRequestMatcher("/boards"),
                                 new AntPathRequestMatcher("/boards/*"),

--- a/src/main/java/com/example/mini_community/common/config/SecurityConfig.java
+++ b/src/main/java/com/example/mini_community/common/config/SecurityConfig.java
@@ -42,7 +42,8 @@ public class SecurityConfig {
                                 new AntPathRequestMatcher("/boards/*"),
                                 new AntPathRequestMatcher("/boards/*/like"),
                                 new AntPathRequestMatcher("/boards/*/comments"),
-                                new AntPathRequestMatcher("/boards/*/comments/*")
+                                new AntPathRequestMatcher("/boards/*/comments/*"),
+                                new AntPathRequestMatcher("/members/*")
                         ).permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/example/mini_community/controller/auth/AuthController.java
+++ b/src/main/java/com/example/mini_community/controller/auth/AuthController.java
@@ -37,4 +37,11 @@ public class AuthController {
 
         return CustomResponse.response(HttpStatus.CREATED, "accessToken을 정상적으로 발급했습니다.", newAccessToken);
     }
+
+    @DeleteMapping("/leave")
+    @ResponseStatus(HttpStatus.OK)
+    public CustomResponse deleteMember(@Validated @RequestBody PasswordValidateRequest req, @Login Member member) {
+        authService.deleteMember(member, req);
+        return CustomResponse.response(HttpStatus.OK, member.getNickname() + "님이 탈퇴했습니다.");
+    }
 }

--- a/src/main/java/com/example/mini_community/controller/member/MemberController.java
+++ b/src/main/java/com/example/mini_community/controller/member/MemberController.java
@@ -4,6 +4,7 @@ import com.example.mini_community.common.annotation.Login;
 import com.example.mini_community.common.response.CustomResponse;
 import com.example.mini_community.domain.member.Member;
 import com.example.mini_community.dto.board.BoardsWithPaginationResponse;
+import com.example.mini_community.dto.member.MemberDto;
 import com.example.mini_community.service.member.MemberService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -37,5 +38,12 @@ public class MemberController {
     public CustomResponse findMyCommentBoards(@Login Member member, @RequestParam(value = "page", defaultValue = "0") Integer page) {
         BoardsWithPaginationResponse boards = memberService.findCommentBoardByMember(member, page);
         return CustomResponse.response(HttpStatus.OK, "내가 작성한 댓글이 포함된 게시물을 정상적으로 조회했습니다.", boards);
+    }
+
+    @GetMapping()
+    @ResponseStatus(HttpStatus.OK)
+    public CustomResponse findMyInformation(@Login Member member) {
+        MemberDto memberInfo = memberService.findMyInformation(member);
+        return CustomResponse.response(HttpStatus.OK, member.getNickname() + "님의 정보를 정상적으로 조회했습니다.", memberInfo);
     }
 }

--- a/src/main/java/com/example/mini_community/controller/member/MemberController.java
+++ b/src/main/java/com/example/mini_community/controller/member/MemberController.java
@@ -20,16 +20,22 @@ public class MemberController {
     private final MemberService memberService;
     @GetMapping("/boards")
     @ResponseStatus(HttpStatus.OK)
-    public CustomResponse findMyBoard(@Login Member member, @RequestParam(value = "page", defaultValue = "0") Integer page) {
+    public CustomResponse findMyBoards(@Login Member member, @RequestParam(value = "page", defaultValue = "0") Integer page) {
         BoardsWithPaginationResponse boards = memberService.findBoardByMember(member, page);
         return CustomResponse.response(HttpStatus.OK, "내가 작성한 게시물을 정상적으로 조회했습니다.", boards);
     }
 
     @GetMapping("/liked")
     @ResponseStatus(HttpStatus.OK)
-    public CustomResponse findMyLikedBoard(@Login Member member, @RequestParam(value = "page", defaultValue = "0") Integer page) {
+    public CustomResponse findMyLikedBoards(@Login Member member, @RequestParam(value = "page", defaultValue = "0") Integer page) {
         BoardsWithPaginationResponse boards = memberService.findLikedBoardByMember(member, page);
         return CustomResponse.response(HttpStatus.OK, "내가 좋아요한 게시물을 정상적으로 조회했습니다.", boards);
     }
 
+    @GetMapping("/comments")
+    @ResponseStatus(HttpStatus.OK)
+    public CustomResponse findMyCommentBoards(@Login Member member, @RequestParam(value = "page", defaultValue = "0") Integer page) {
+        BoardsWithPaginationResponse boards = memberService.findCommentBoardByMember(member, page);
+        return CustomResponse.response(HttpStatus.OK, "내가 작성한 댓글이 포함된 게시물을 정상적으로 조회했습니다.", boards);
+    }
 }

--- a/src/main/java/com/example/mini_community/controller/member/MemberController.java
+++ b/src/main/java/com/example/mini_community/controller/member/MemberController.java
@@ -3,12 +3,14 @@ package com.example.mini_community.controller.member;
 import com.example.mini_community.common.annotation.Login;
 import com.example.mini_community.common.response.CustomResponse;
 import com.example.mini_community.domain.member.Member;
+import com.example.mini_community.dto.auth.EditMemberRequest;
 import com.example.mini_community.dto.board.BoardsWithPaginationResponse;
 import com.example.mini_community.dto.member.MemberDto;
 import com.example.mini_community.service.member.MemberService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 
@@ -40,10 +42,17 @@ public class MemberController {
         return CustomResponse.response(HttpStatus.OK, "내가 작성한 댓글이 포함된 게시물을 정상적으로 조회했습니다.", boards);
     }
 
-    @GetMapping()
+    @GetMapping("/member")
     @ResponseStatus(HttpStatus.OK)
     public CustomResponse findMyInformation(@Login Member member) {
         MemberDto memberInfo = memberService.findMyInformation(member);
         return CustomResponse.response(HttpStatus.OK, member.getNickname() + "님의 정보를 정상적으로 조회했습니다.", memberInfo);
+    }
+
+    @PutMapping()
+    @ResponseStatus(HttpStatus.OK)
+    public CustomResponse editMyProfile(@Validated @RequestBody EditMemberRequest req, @Login Member member) {
+        MemberDto memberInfo = memberService.editMyProfile(member, req);
+        return CustomResponse.response(HttpStatus.OK, member.getNickname() + "님의 프로필 정보를 정상적으로 수정했습니다.", memberInfo);
     }
 }

--- a/src/main/java/com/example/mini_community/controller/member/MemberController.java
+++ b/src/main/java/com/example/mini_community/controller/member/MemberController.java
@@ -1,0 +1,35 @@
+package com.example.mini_community.controller.member;
+
+import com.example.mini_community.common.annotation.Login;
+import com.example.mini_community.common.response.CustomResponse;
+import com.example.mini_community.domain.member.Member;
+import com.example.mini_community.dto.board.BoardsWithPaginationResponse;
+import com.example.mini_community.service.member.MemberService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+
+@RestController
+@Slf4j
+@RequiredArgsConstructor
+@RequestMapping("/members")
+public class MemberController {
+
+    private final MemberService memberService;
+    @GetMapping("/boards")
+    @ResponseStatus(HttpStatus.OK)
+    public CustomResponse findMyBoard(@Login Member member, @RequestParam(value = "page", defaultValue = "0") Integer page) {
+        BoardsWithPaginationResponse boards = memberService.findBoardByMember(member, page);
+        return CustomResponse.response(HttpStatus.OK, "내가 작성한 게시물을 정상적으로 조회했습니다.", boards);
+    }
+
+    @GetMapping("/liked")
+    @ResponseStatus(HttpStatus.OK)
+    public CustomResponse findMyLikedBoard(@Login Member member, @RequestParam(value = "page", defaultValue = "0") Integer page) {
+        BoardsWithPaginationResponse boards = memberService.findLikedBoardByMember(member, page);
+        return CustomResponse.response(HttpStatus.OK, "내가 좋아요한 게시물을 정상적으로 조회했습니다.", boards);
+    }
+
+}

--- a/src/main/java/com/example/mini_community/domain/member/Member.java
+++ b/src/main/java/com/example/mini_community/domain/member/Member.java
@@ -54,6 +54,11 @@ public class Member extends BaseTimeEntity implements UserDetails {
         this.password = password;
     }
 
+    public void update(String nickname, String profile_img){
+        this.nickname = nickname;
+        this.profile_img = profile_img;
+    }
+
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return List.of(new SimpleGrantedAuthority("member"));

--- a/src/main/java/com/example/mini_community/dto/auth/EditMemberRequest.java
+++ b/src/main/java/com/example/mini_community/dto/auth/EditMemberRequest.java
@@ -1,0 +1,18 @@
+package com.example.mini_community.dto.auth;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@AllArgsConstructor
+public class EditMemberRequest {
+    @NotBlank(message="닉네임을 입력하지 않았습니다.")
+    private String nickname;
+
+    private String profile_img;
+}

--- a/src/main/java/com/example/mini_community/dto/auth/PasswordValidateRequest.java
+++ b/src/main/java/com/example/mini_community/dto/auth/PasswordValidateRequest.java
@@ -1,0 +1,16 @@
+package com.example.mini_community.dto.auth;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class PasswordValidateRequest {
+    @NotBlank(message="비밀번호를 입력하지 않았습니다.")
+    @Size(min=8, max=16, message = "비밀번호는 8글자 이상, 16글자 이하여야 합니다.")
+    private String password;
+}

--- a/src/main/java/com/example/mini_community/dto/member/MemberDto.java
+++ b/src/main/java/com/example/mini_community/dto/member/MemberDto.java
@@ -1,0 +1,17 @@
+package com.example.mini_community.dto.member;
+
+import com.example.mini_community.domain.member.Member;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MemberDto {
+    private String email;
+    private String profileImg;
+    private String nickname;
+
+    public static MemberDto toDto(Member member) {
+        return new MemberDto(member.getEmail(), member.getProfile_img(), member.getNickname());
+    }
+}

--- a/src/main/java/com/example/mini_community/repository/board/BoardRepository.java
+++ b/src/main/java/com/example/mini_community/repository/board/BoardRepository.java
@@ -1,6 +1,7 @@
 package com.example.mini_community.repository.board;
 
 import com.example.mini_community.domain.board.Board;
+import com.example.mini_community.domain.member.Member;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -14,4 +15,5 @@ public interface BoardRepository extends JpaRepository<Board, UUID> {
     Page<Board> findByContentContaining(String keyword, Pageable pageable);
     Page<Board> findByTitleContaining(String keyword, Pageable pageable);
     Page<Board> findByMemberNicknameContaining(String keyword, Pageable pageable);
+    Page<Board> findByMember(Member member, Pageable pageable);
 }

--- a/src/main/java/com/example/mini_community/repository/board/LikedBoardRepository.java
+++ b/src/main/java/com/example/mini_community/repository/board/LikedBoardRepository.java
@@ -3,10 +3,13 @@ package com.example.mini_community.repository.board;
 import com.example.mini_community.domain.board.Board;
 import com.example.mini_community.domain.board.LikedBoard;
 import com.example.mini_community.domain.member.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface LikedBoardRepository extends JpaRepository<LikedBoard, Long> {
     Optional<LikedBoard> findByBoardAndMember(Board board, Member member);
+    Page<LikedBoard> findByMember(Member member, Pageable pageable);
 }

--- a/src/main/java/com/example/mini_community/repository/comment/CommentRepository.java
+++ b/src/main/java/com/example/mini_community/repository/comment/CommentRepository.java
@@ -1,6 +1,9 @@
 package com.example.mini_community.repository.comment;
 
 import com.example.mini_community.domain.comment.Comment;
+import com.example.mini_community.domain.member.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -10,4 +13,5 @@ import java.util.UUID;
 public interface CommentRepository extends JpaRepository<Comment, UUID> {
     Optional<Comment> findById(UUID id);
     List<Comment> findByBoardIdOrderByCreatedAtAsc(UUID id);
+    Page<Comment> findByMember(Member member, Pageable pageable);
 }

--- a/src/main/java/com/example/mini_community/service/auth/AuthService.java
+++ b/src/main/java/com/example/mini_community/service/auth/AuthService.java
@@ -109,4 +109,12 @@ public class AuthService {
         Long memberId = tokenProvider.getMemberId(token);
         return memberService.findById(memberId);
     }
+
+    @Transactional
+    public void deleteMember(Member member, PasswordValidateRequest req) {
+        if(!bCryptPasswordEncoder.matches(req.getPassword(), member.getPassword())) {
+            throw new BusinessException(WRONG_PASSWORD);
+        }
+        memberService.deleteMember(member);
+    }
 }

--- a/src/main/java/com/example/mini_community/service/board/BoardService.java
+++ b/src/main/java/com/example/mini_community/service/board/BoardService.java
@@ -58,7 +58,21 @@ public class BoardService {
     @Transactional
     public BoardsWithPaginationResponse findAll(Integer page) {
         Pageable pageable = makePageable(page);
-        Page<Board> boards = findAllWithPageable(pageable);
+        Page<Board> boards = boardRepository.findAll(pageable);
+        return makeAllBoardsResponse(boards);
+    }
+
+    @Transactional
+    public BoardsWithPaginationResponse findBoardByMember(Member member, Integer page) {
+        Pageable pageable = makePageable(page);
+        Page<Board> boards = boardRepository.findByMember(member, pageable);
+        return makeAllBoardsResponse(boards);
+    }
+
+    @Transactional
+    public BoardsWithPaginationResponse findLikedBoardByMember(Member member, Integer page) {
+        Pageable pageable = makePageable(page);
+        Page<Board> boards = likedBoardRepository.findByMember(member, pageable).map(LikedBoard::getBoard);
         return makeAllBoardsResponse(boards);
     }
 
@@ -86,10 +100,6 @@ public class BoardService {
 
     private Pageable makePageable(Integer page) {
         return PageRequest.of(page, PAGE_SIZE, Sort.by("createdAt").descending());
-    }
-
-    private Page<Board> findAllWithPageable(Pageable pageable) {
-        return boardRepository.findAll(pageable);
     }
 
     private BoardsWithPaginationResponse makeAllBoardsResponse(Page<Board> boards) {
@@ -139,6 +149,7 @@ public class BoardService {
         deleteImagesByBoard(board);
         boardRepository.delete(board);
     }
+
 
     @Transactional
     public BoardLikeResponse updateLikeCount(UUID id, Member member) {

--- a/src/main/java/com/example/mini_community/service/member/MemberService.java
+++ b/src/main/java/com/example/mini_community/service/member/MemberService.java
@@ -3,6 +3,7 @@ package com.example.mini_community.service.member;
 import com.example.mini_community.common.exception.BusinessException;
 import com.example.mini_community.domain.member.Member;
 import com.example.mini_community.dto.board.BoardsWithPaginationResponse;
+import com.example.mini_community.dto.member.MemberDto;
 import com.example.mini_community.repository.member.MemberRepository;
 import com.example.mini_community.service.board.BoardService;
 import jakarta.transaction.Transactional;
@@ -46,5 +47,11 @@ public class MemberService {
     @Transactional
     public BoardsWithPaginationResponse findCommentBoardByMember(Member member, Integer page) {
         return boardService.findCommentBoardByMember(member, page);
+    }
+
+    @Transactional
+    public MemberDto findMyInformation(Member member) {
+        Member loginMember =  memberRepository.findById(member.getId()).orElseThrow(() -> new BusinessException(MEMBER_NOT_FOUND));
+         return MemberDto.toDto(loginMember);
     }
 }

--- a/src/main/java/com/example/mini_community/service/member/MemberService.java
+++ b/src/main/java/com/example/mini_community/service/member/MemberService.java
@@ -2,7 +2,9 @@ package com.example.mini_community.service.member;
 
 import com.example.mini_community.common.exception.BusinessException;
 import com.example.mini_community.domain.member.Member;
+import com.example.mini_community.dto.board.BoardsWithPaginationResponse;
 import com.example.mini_community.repository.member.MemberRepository;
+import com.example.mini_community.service.board.BoardService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,6 +18,8 @@ public class MemberService {
 
     @Autowired
     private MemberRepository memberRepository;
+    @Autowired
+    private BoardService boardService;
 
     @Transactional
     public Member findByEmail(String email) {
@@ -27,5 +31,15 @@ public class MemberService {
     public Member findById(Long id) {
         return memberRepository.findById(id)
                 .orElseThrow(() -> new BusinessException(MEMBER_NOT_FOUND));
+    }
+
+    @Transactional
+    public BoardsWithPaginationResponse findBoardByMember(Member member, Integer page) {
+        return boardService.findBoardByMember(member, page);
+    }
+
+    @Transactional
+    public BoardsWithPaginationResponse findLikedBoardByMember(Member member, Integer page) {
+        return boardService.findLikedBoardByMember(member, page);
     }
 }

--- a/src/main/java/com/example/mini_community/service/member/MemberService.java
+++ b/src/main/java/com/example/mini_community/service/member/MemberService.java
@@ -42,4 +42,9 @@ public class MemberService {
     public BoardsWithPaginationResponse findLikedBoardByMember(Member member, Integer page) {
         return boardService.findLikedBoardByMember(member, page);
     }
+
+    @Transactional
+    public BoardsWithPaginationResponse findCommentBoardByMember(Member member, Integer page) {
+        return boardService.findCommentBoardByMember(member, page);
+    }
 }

--- a/src/main/java/com/example/mini_community/service/member/MemberService.java
+++ b/src/main/java/com/example/mini_community/service/member/MemberService.java
@@ -2,6 +2,7 @@ package com.example.mini_community.service.member;
 
 import com.example.mini_community.common.exception.BusinessException;
 import com.example.mini_community.domain.member.Member;
+import com.example.mini_community.dto.auth.EditMemberRequest;
 import com.example.mini_community.dto.board.BoardsWithPaginationResponse;
 import com.example.mini_community.dto.member.MemberDto;
 import com.example.mini_community.repository.member.MemberRepository;
@@ -53,5 +54,11 @@ public class MemberService {
     public MemberDto findMyInformation(Member member) {
         Member loginMember =  memberRepository.findById(member.getId()).orElseThrow(() -> new BusinessException(MEMBER_NOT_FOUND));
          return MemberDto.toDto(loginMember);
+    }
+
+    @Transactional
+    public MemberDto editMyProfile(Member member, EditMemberRequest req) {
+        member.update(req.getNickname(), req.getProfile_img());
+        return MemberDto.toDto(member);
     }
 }

--- a/src/main/java/com/example/mini_community/service/member/MemberService.java
+++ b/src/main/java/com/example/mini_community/service/member/MemberService.java
@@ -61,4 +61,8 @@ public class MemberService {
         member.update(req.getNickname(), req.getProfile_img());
         return MemberDto.toDto(member);
     }
+
+    public void deleteMember(Member member) {
+        memberRepository.delete(member);
+    }
 }


### PR DESCRIPTION
[ 추가한 API ]
- 내가 작성한 게시물 조회
- 내가 좋아요한 게시물 조회
- 내가 작성한 댓글이 포함된 게시물 조회
- 내 정보 확인
- 내 프로필 정보 수정
- 회원탈퇴 (비밀번호 재확인 후 진행하도록)

[ Todo ]
- 프로필 정보 수정 후 사용자의 재로그인 없이 수정된 정보를 띄울 수 있는 방안 찾기